### PR TITLE
Add MacOSKeychainSearchList class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ group "com.wooga.security"
 
 dependencies {
     implementation 'org.codehaus.groovy:groovy-all:2.4.15'
+    testImplementation 'com.github.stefanbirkner:system-rules:1.18.0'
     testImplementation 'org.spockframework:spock-core:1.2-groovy-2.4'
 }
 List<String> cliTasks = project.rootProject.gradle.startParameter.taskNames

--- a/src/main/groovy/com/wooga/security/MacOsKeychainSearchList.groovy
+++ b/src/main/groovy/com/wooga/security/MacOsKeychainSearchList.groovy
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security
+
+import com.wooga.security.command.DefaultKeychain
+import com.wooga.security.command.ListKeychains
+
+class MacOsKeychainSearchList implements List<File>, Set<File> {
+
+    private class KeychainSearchListIterator implements Iterator<File> {
+        private Iterator<File> innerIterator
+        private File current
+
+        KeychainSearchListIterator(Iterator<File> innerIterator) {
+            this.innerIterator = innerIterator
+        }
+
+        @Override
+        boolean hasNext() {
+            return innerIterator.hasNext()
+        }
+
+        @Override
+        File next() {
+            current = innerIterator.next()
+            return current
+        }
+
+        @Override
+        void remove() {
+            remove(current)
+        }
+    }
+
+    private class KeychainLookupListIterator implements ListIterator<File> {
+        private ListIterator<File> innerIterator
+        private File current
+
+        KeychainLookupListIterator(ListIterator<File> innerIterator) {
+            this.innerIterator = innerIterator
+        }
+
+        @Override
+        boolean hasNext() {
+            return innerIterator.hasNext()
+        }
+
+        @Override
+        File next() {
+            current = innerIterator.next()
+            return current
+        }
+
+        @Override
+        void remove() {
+            remove(current)
+        }
+
+        @Override
+        boolean hasPrevious() {
+            return innerIterator.hasPrevious()
+        }
+
+        @Override
+        File previous() {
+            current = innerIterator.previous()
+            return current
+        }
+
+        @Override
+        int nextIndex() {
+            return innerIterator.nextIndex()
+        }
+
+        @Override
+        int previousIndex() {
+            return innerIterator.previousIndex()
+        }
+
+        @Override
+        void set(File file) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        void add(File file) {
+            throw new UnsupportedOperationException()
+        }
+    }
+
+    private final Domain domain
+
+    MacOsKeychainSearchList(Domain domain = null) {
+        this.domain = domain
+    }
+
+    private static List<File> listKeychains(Domain domain) {
+        new ListKeychains().withDomain(domain).execute()
+    }
+
+    private static void setKeychains(Iterable<File> keychains, Domain domain) {
+        new ListKeychains().withDomain(domain).withKeychains(keychains).setKeychainSearchList().execute()
+    }
+
+    @Override
+    int size() {
+        listKeychains(domain).size()
+    }
+
+    @Override
+    boolean isEmpty() {
+        size() == 0
+    }
+
+    @Override
+    boolean contains(Object o) {
+        Objects.requireNonNull(o)
+
+        if (!File.isInstance(o)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        File keychain = o as File
+        listKeychains(domain).contains(canonical(keychain))
+    }
+
+    @Override
+    Iterator<File> iterator() {
+        new KeychainSearchListIterator(listKeychains(domain).iterator())
+    }
+
+    @Override
+    Object[] toArray() {
+        listKeychains(domain).toArray()
+    }
+
+    @Override
+    def <T> T[] toArray(T[] a) {
+        listKeychains(domain).toArray(a)
+    }
+
+    @Override
+    boolean add(File keychain) {
+        Objects.requireNonNull(keychain)
+        keychain = canonical(keychain)
+        def keychains = listKeychains(domain)
+        if (!keychains.contains(keychain) && keychains.add(keychain)) {
+            setKeychains(keychains, domain)
+            return true
+        }
+        false
+    }
+
+    @Override
+    boolean remove(Object o) {
+        Objects.requireNonNull(o)
+
+        if (!File.isInstance(o)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        File k = canonical(o as File)
+        def keychains = listKeychains(domain)
+        if (keychains.remove(k)) {
+            setKeychains(keychains, domain)
+            return true
+        }
+        false
+    }
+
+    @Override
+    boolean containsAll(Collection<?> c) {
+        Objects.requireNonNull(c as Object)
+        def keychains = c.collect {
+            if (!File.isInstance(it)) {
+                throw new ClassCastException("expect object of type java.io.File")
+            }
+            canonical(it as File)
+        }
+        listKeychains(domain).containsAll(keychains)
+    }
+
+    @Override
+    boolean addAll(Collection<? extends File> c) {
+        Objects.requireNonNull(c)
+        def keychains = listKeychains(domain)
+        if (keychains.addAll(c)) {
+            setKeychains(keychains, domain)
+            return true
+        }
+        false
+    }
+
+    @Override
+    boolean addAll(int index, Collection<? extends File> c) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    boolean removeAll(Collection<?> c) {
+        Objects.requireNonNull(c as Object)
+        def keychainsToRemove = c.collect {
+            if (!File.isInstance(it)) {
+                throw new ClassCastException("expect object of type java.io.File")
+            }
+            canonical(it as File)
+        }
+        def keychains = listKeychains(domain)
+        def result = keychains.removeAll(keychainsToRemove)
+        new ListKeychains().withDomain(domain).withKeychains(keychains).setKeychainSearchList().execute()
+        result
+    }
+
+    @Override
+    boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    void clear() {
+        reset()
+    }
+
+    void reset() {
+        resetKeychains(domain)
+    }
+
+    @Override
+    File get(int index) {
+        listKeychains(domain).get(index)
+    }
+
+    @Override
+    File set(int index, File element) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    void add(int index, File element) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    File remove(int index) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    int indexOf(Object o) {
+        Objects.requireNonNull(o)
+
+        if (!File.isInstance(o)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        listKeychains(domain).indexOf(canonical(o as File))
+    }
+
+    @Override
+    int lastIndexOf(Object o) {
+        Objects.requireNonNull(o)
+
+        if (!File.isInstance(o)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        listKeychains(domain).lastIndexOf(canonical(o as File))
+    }
+
+    @Override
+    ListIterator<File> listIterator() {
+        listIterator(0)
+    }
+
+    @Override
+    ListIterator<File> listIterator(int index) {
+        new KeychainLookupListIterator(listKeychains(domain).listIterator(index))
+    }
+
+    @Override
+    List<File> subList(int fromIndex, int toIndex) {
+        listKeychains(domain).subList(fromIndex, toIndex)
+    }
+
+    File getLoginKeyChain() {
+        getLoginKeyChain(domain)
+    }
+
+    File getDefaultKeyChain() {
+        getDefaultKeyChain(domain)
+    }
+
+    static File getLoginKeyChain(Domain domain) {
+        new DefaultKeychain().withDomain(domain).execute()
+    }
+
+    static File getDefaultKeyChain(Domain domain) {
+        new DefaultKeychain().withDomain(domain).execute()
+    }
+
+    static String expandPath(String path) {
+        if (path.startsWith("~" + File.separator)) {
+            path = System.getProperty("user.home") + path.substring(1)
+        }
+        path
+    }
+
+    static File expandPath(File path) {
+        new File(expandPath(path.path))
+    }
+
+    static File canonical(File keychain) {
+        expandPath(keychain).canonicalFile
+    }
+
+    static void resetKeychains(Domain domain = Domain.user) {
+        def rawValue = System.getenv().get("ATLAS_BUILD_UNITY_IOS_DEFAULT_KEYCHAINS")
+        def defaultKeyChains
+        if (rawValue) {
+            defaultKeyChains = rawValue.split(File.pathSeparator).collect { canonical(new File(it)) }
+        } else {
+            defaultKeyChains = [getLoginKeyChain(domain), getDefaultKeyChain(domain)].unique()
+        }
+        setKeychains(defaultKeyChains, domain)
+    }
+}

--- a/src/test/groovy/com/wooga/security/MacOsKeychainSearchListSpec.groovy
+++ b/src/test/groovy/com/wooga/security/MacOsKeychainSearchListSpec.groovy
@@ -1,0 +1,660 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security
+
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.junit.contrib.java.lang.system.ProvideSystemProperty
+import spock.lang.*
+import spock.util.environment.RestoreSystemProperties
+
+@Requires({ os.macOs && env['ATLAS_BUILD_UNITY_IOS_EXECUTE_KEYCHAIN_SPEC'] == 'YES' })
+@RestoreSystemProperties
+class MacOsKeychainSearchListSpec extends Specification {
+
+    @Shared
+    File newHome = File.createTempDir("user", "home")
+
+    @Rule
+    public ProvideSystemProperty systemProperties = new ProvideSystemProperty("user.home", newHome.path)
+
+    @Shared
+    MacOsKeychainSearchList subject = new MacOsKeychainSearchList(Domain.user)
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    def setup() {
+        newHome.mkdirs()
+        MacOsKeychainSearchList.resetKeychains()
+    }
+
+    def cleanup() {
+        MacOsKeychainSearchList.resetKeychains()
+    }
+
+    def cleanupSpec() {
+        MacOsKeychainSearchList.resetKeychains()
+    }
+
+    File createTestKeychainFromPath(String path) {
+        if (path.startsWith("~" + File.separator)) {
+            path = System.getProperty("user.home") + path.substring(1)
+        }
+        def f = new File(path).canonicalFile
+        createTestKeychain(f.name, f.parentFile)
+    }
+
+    File createTestKeychain(String fileName, File baseDir = File.createTempDir()) {
+        fileName = fileName.endsWith(".keychain") ? fileName : "${fileName}.keychain"
+        def keychain = new File(baseDir, fileName)
+        baseDir.mkdirs()
+        keychain << "A test keychain file mock"
+        keychain
+    }
+
+    def "populated list has size != 0"() {
+        given: "a populated list"
+        subject.add(createTestKeychain("test1"))
+        subject.add(createTestKeychain("test2"))
+
+        expect:
+        subject.size() != 0
+        !subject.isEmpty()
+    }
+
+    def "adds a single keychain to the lookup list"() {
+        given: "a empty lookup list"
+        def initialSize = subject.size()
+        assert subject.size() != 0
+
+        when:
+        def k1 = createTestKeychain("test")
+        def result = subject.add(k1)
+
+        then:
+        result
+        subject.size() == initialSize + 1
+        subject.contains(k1)
+
+        when:
+        def k2 = createTestKeychain("test2")
+        result = subject.add(k2)
+
+        then:
+        result
+        subject.size() == initialSize + 2
+        subject.contains(k1)
+        subject.contains(k2)
+    }
+
+    def "adds multiple keychains to the lookup list"() {
+        given: "a empty lookup list"
+        def initialSize = subject.size()
+        assert subject.size() != 0
+
+        when:
+        def k1 = createTestKeychain("test.keychain")
+        def k2 = createTestKeychain("test2.keychain")
+        def k3 = createTestKeychain("test3.keychain")
+        def k4 = createTestKeychain("test4.keychain")
+        def result = subject.addAll([k1, k2])
+
+        then:
+        result
+        subject.size() == initialSize + 2
+        subject.contains(k1)
+        subject.contains(k2)
+
+        when:
+        result = subject.addAll([k3, k4])
+
+        then:
+        result
+        subject.size() == initialSize + 4
+        subject.contains(k1)
+        subject.contains(k2)
+        subject.contains(k3)
+        subject.contains(k4)
+    }
+
+    @Unroll
+    def "doesn't add duplicate entries when #message"() {
+        given: "lookup list with one entry"
+        def initialSize = subject.size()
+        def keychain = createTestKeychain("test.keychain", new File(newHome, "path/to"))
+        subject.add(keychain)
+        assert subject.size() == initialSize + 1
+
+        when:
+        def result = subject.add(new File(fileToAdd))
+
+        then:
+        !result
+        subject.size() == initialSize + 1
+
+        where:
+        fileToAdd                                       | message
+        "~/path/to/test.keychain"                       | "path is equal"
+        "~/path/../path/to/test.keychain"               | "resolved path is equal"
+        "${newHome.path}/path/../path/to/test.keychain" | "expanded ~/ path is equal"
+    }
+
+    @Unroll
+    def "#method throws #error when #message"() {
+        when:
+        subject.invokeMethod(method, testObject)
+
+        then:
+        thrown(error)
+
+        where:
+        method        | testObject | error                     | message
+        "contains"    | null       | NullPointerException      | "object is null"
+        "indexOf"     | null       | NullPointerException      | "object is null"
+        "lastIndexOf" | null       | NullPointerException      | "object is null"
+        "contains"    | "test"     | ClassCastException        | "object is not a java.io.File"
+        "remove"      | "test"     | ClassCastException        | "object is not a java.io.File"
+        "indexOf"     | "test"     | ClassCastException        | "object is not a java.io.File"
+        "lastIndexOf" | "test"     | ClassCastException        | "object is not a java.io.File"
+        "add"         | "test"     | ClassCastException        | "object is not a java.io.File"
+        "get"         | 22         | IndexOutOfBoundsException | "index is out of bounds"
+    }
+
+    // need to unroll these cases by hand because `invokeMethod` calls them with:
+    // - non null default buildArguments
+    // or
+    // - doesn't know which overload to call
+
+    def "retainAll throws UnsupportedOperationException"() {
+        when:
+        subject.retainAll(null)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "set(int,File) throws UnsupportedOperationException"() {
+        when:
+        subject.set(0, new File('some/file'))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "add(int,File) throws UnsupportedOperationException"() {
+        when:
+        subject.add(0, new File('some/file'))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "remove(int) throws UnsupportedOperationException"() {
+        when:
+        subject.remove(0)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "addAll(int, Collection<? extends File>) throws UnsupportedOperationException"() {
+        when:
+        subject.addAll(0, [new File('some/file')])
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+
+    def "remove throws NullPointerException when object is null"() {
+        when:
+        subject.remove(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "add throws NullPointerException when object is null"() {
+        when:
+        subject.add(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "addAll throws NullPointerException when object is null"() {
+        when:
+        subject.addAll(null as Collection)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "addAll throws NullPointerException when one or more objects in list are null"() {
+        when:
+        subject.addAll([createTestKeychain("test.keychain"), null])
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "removeAll throws NullPointerException when object is null"() {
+        when:
+        subject.removeAll(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "containsAll throws NullPointerException when object is null"() {
+        when:
+        subject.containsAll(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "containsAll throws ClassCastException when one or more objects in list are not of type java.io.File"() {
+        when:
+        subject.containsAll([new File('some/file'), "a String"])
+
+        then:
+        thrown(ClassCastException)
+    }
+
+    def "toArray throws NullPointerException when object is null"() {
+        when:
+        subject.toArray(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "toArray throws ArrayStoreException when object is not a java.io.File[] array"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+
+        when:
+        subject.toArray(new String[0])
+
+        then:
+        thrown(ArrayStoreException)
+    }
+
+    @Unroll
+    def "contains checks if resolved path are equal when #message"() {
+        given: "lookup list with one entry"
+        def initialSize = subject.size()
+        subject.add(new File("~/path/to/test.keychain"))
+        assert subject.size() == initialSize + 1
+
+        expect:
+        subject.contains(new File(fileToCheck))
+
+        where:
+        fileToCheck                                     | message
+        //"~/path/to/test.keychain"                       | "path is equal"
+        //"~/path/../path/to/test.keychain"               | "resolved path is equal"
+        "${newHome.path}/path/../path/to/test.keychain" | "expanded ~/ path is equal"
+    }
+
+    @Unroll
+    def "containsAll checks if all keychains provided are in the list"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        expect:
+        subject.containsAll(check) == expectedValue
+
+        where:
+        check                                                                       || expectedValue
+        [new File("~/path/to/test.keychain")]                                       || true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test2.keychain")] || true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test4.keychain")] || false
+        [new File("~/path/to/test4.keychain")]                                      || false
+    }
+
+    @Unroll
+    def "clear resets keychain"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        subject.clear()
+
+        then:
+        !subject.isEmpty()
+        subject.size() == initialSize
+        !subject.contains(MacOsKeychainSearchList.canonical(new File("~/path/to/test.keychain")))
+        !subject.contains(MacOsKeychainSearchList.canonical(new File("~/path/to/test2.keychain")))
+        !subject.contains(MacOsKeychainSearchList.canonical(new File("~/path/to/test3.keychain")))
+    }
+
+    @Unroll
+    def "removes items from the list when #message"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        def result = subject.remove(new File(fileToRemove))
+
+        then:
+        result
+        subject.size() == initialSize + 2
+        !subject.contains(new File(fileToRemove))
+
+        where:
+        fileToRemove                                    | message
+        "~/path/to/test.keychain"                       | "path is equal"
+        "~/path/../path/to/test.keychain"               | "resolved path is equal"
+        "${newHome.path}/path/../path/to/test.keychain" | "expanded ~/ path is equal"
+    }
+
+    @Unroll
+    def "removes multiple items from the list"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        def result = subject.removeAll(filesToRemove)
+
+        then:
+        result == hasChanges
+        subject.size() == initialSize + expectedSize
+        !subject.containsAll(filesToRemove)
+
+        where:
+        filesToRemove                                                               || expectedSize | hasChanges
+        [new File("~/path/to/test.keychain")]                                       || 2            | true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test2.keychain")] || 1            | true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test4.keychain")] || 2            | true
+        [new File("~/path/to/test4.keychain")]                                      || 3            | false
+    }
+
+    @Unroll
+    def "creates #type over items"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        and: "a check counter"
+        def checkList = []
+
+        when:
+        def iter = subject.invokeMethod(method, null)
+        while (iter.hasNext()) {
+            checkList.add(iter.next())
+        }
+
+        then:
+        checkList.size() == subject.size()
+        subject.containsAll(checkList)
+
+        where:
+        type            | method
+        "iterator"      | "iterator"
+        "list iterator" | "listIterator"
+    }
+
+    @Unroll
+    def "list iterator can move in both directions"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        and: "a check counter"
+        def checkList = []
+
+        when:
+        def iter = subject.listIterator(3)
+        while (iter.hasPrevious()) {
+            iter.previousIndex()
+            checkList.add(iter.previous())
+        }
+
+        then:
+        checkList.size() + initialSize == subject.size()
+        subject.containsAll(checkList)
+
+        when:
+        checkList.clear()
+        iter = subject.listIterator(0)
+        while (iter.hasNext()) {
+            iter.nextIndex()
+            checkList.add(iter.next())
+        }
+
+        then:
+        checkList.size() == subject.size()
+        subject.containsAll(checkList)
+    }
+
+    def "list iterator doesn't support set(File)"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        def iter = subject.listIterator()
+        iter.next()
+        iter.set(new File("some/file"))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "list iterator doesn't support add(File)"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        def iter = subject.listIterator()
+        iter.next()
+        iter.add(new File("some/file"))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    @Unroll
+    def "#type can modify lookup list"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        Iterator iter = subject.invokeMethod(method, null)
+        while (iter.hasNext()) {
+            if (iter.next() == MacOsKeychainSearchList.canonical(new File("~/path/to/test2.keychain"))) {
+                iter.remove()
+            }
+        }
+
+        then:
+        subject.size() == initialSize + 2
+        !subject.contains(new File("~/path/to/test2.keychain"))
+
+        where:
+        type            | method
+        "iterator"      | "iterator"
+        "list iterator" | "listIterator"
+    }
+
+    def "creates Object[] array copy of items"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        def arr = subject.toArray()
+
+        then:
+        arr.length == subject.size()
+        subject.containsAll(arr)
+
+        when:
+        arr = subject.toArray()
+        subject.remove(new File("~/path/to/test2.keychain"))
+
+        then:
+        arr.length != subject.size()
+        !subject.containsAll(arr)
+    }
+
+    @Unroll
+    def "creates File[] array copy of items with #testArr"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        and:
+        def expectSameSize = testArr.length <= subject.size()
+
+        when:
+        def arr = subject.toArray(testArr)
+
+        then:
+        (arr.length == subject.size()) == expectSameSize
+        subject.containsAll(arr.findAll { it != null })
+
+        when:
+        arr = subject.toArray()
+        subject.remove(new File("~/path/to/test2.keychain"))
+
+        then:
+        arr.length != subject.size()
+        !subject.containsAll(arr.findAll { it != null })
+
+        where:
+        testArr << [new File[0], new File[3], new File[5]]
+    }
+
+    def "retrieves item by index"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        expect:
+        subject[initialSize + 1] == MacOsKeychainSearchList.canonical(new File("~/path/to/test2.keychain"))
+    }
+
+    @Unroll
+    def "#method returns #message"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        and: "adjusted expected index"
+        expectedIndex = (expectedIndex >= 0) ? expectedIndex + initialSize : expectedIndex
+
+        expect:
+        subject.invokeMethod(method, item) == expectedIndex
+
+        where:
+        method        | item                                 | message                                | expectedIndex
+        "indexOf"     | new File("~/path/to/test2.keychain") | "index when item is contained in list" | 1
+        "indexOf"     | new File("~/path/to/test4.keychain") | "-1 when item can not be found"        | -1
+        "lastIndexOf" | new File("~/path/to/test2.keychain") | "index when item is contained in list" | 1
+        "lastIndexOf" | new File("~/path/to/test4.keychain") | "-1 when item can not be found"        | -1
+    }
+
+    def "creates a faulty sublist"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        expect:
+        subject.subList(1, 2).size() == 1
+    }
+
+    @Ignore
+    def "reset "() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        and: "a custom reset list"
+        def originalDefaultKeychains = System.getenv("ATLAS_BUILD_UNITY_IOS_DEFAULT_KEYCHAINS")
+        environmentVariables.set("ATLAS_BUILD_UNITY_IOS_DEFAULT_KEYCHAINS", expectedKeychains.join(File.pathSeparator))
+
+        when:
+        subject.reset()
+
+        then:
+        subject.size() == expectedKeychains.size()
+        expectedKeychains.every { subject.contains(new File(it)) }
+
+        cleanup:
+        environmentVariables.set("ATLAS_BUILD_UNITY_IOS_DEFAULT_KEYCHAINS", originalDefaultKeychains)
+        MacOsKeychainSearchList.resetKeychains()
+
+        where:
+        expectedKeychains = ["~/path/to/test.keychain", "~/path/to/test3.keychain"]
+    }
+
+}


### PR DESCRIPTION
## Description

This patch brings a reimplementation of the `KeychainLookupList` now named `MacOSKeychainSearchList` to the security library. I replaced all invocations of `SecurityUtil` from the old class with the new security command versions.

## Changes

* ![ADD] `KeychainSearchList` class

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"