### PR TITLE
Fix sonar publish of sub projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ jacocoTestReport {
     }
 }
 
+allprojects {
+
+}
 nexusPublishing {
     repositories {
         sonatype {
@@ -69,12 +72,16 @@ nexusPublishing {
 
 postRelease.dependsOn(tasks.publish)
 
-afterEvaluate {
-    tasks."final".dependsOn(tasks.publishToSonatype, tasks.closeAndReleaseSonatypeStagingRepository)
-    tasks."candidate".dependsOn(tasks.publishToSonatype, tasks.closeAndReleaseSonatypeStagingRepository)
-    tasks.publishToSonatype.mustRunAfter(tasks.postRelease)
-    tasks.closeSonatypeStagingRepository.mustRunAfter(tasks.publishToSonatype)
-    tasks.publish.mustRunAfter(tasks.release)
+allprojects {
+    afterEvaluate {
+        rootProject.tasks.postRelease.dependsOn(tasks.publish)
+        rootProject.tasks."final".dependsOn(tasks.publishToSonatype, rootProject.tasks.closeAndReleaseSonatypeStagingRepository)
+        rootProject.tasks."final".dependsOn(tasks.publishToSonatype, rootProject.tasks.closeAndReleaseSonatypeStagingRepository)
+        rootProject.tasks."candidate".dependsOn(tasks.publishToSonatype, rootProject.tasks.closeAndReleaseSonatypeStagingRepository)
+        tasks.publishToSonatype.mustRunAfter(rootProject.tasks.postRelease)
+        rootProject.tasks.closeSonatypeStagingRepository.mustRunAfter(tasks.publishToSonatype)
+        tasks.publish.mustRunAfter(rootProject.tasks.release)
+    }
 }
 
 apply from: 'publish-helper.gradle'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -20,4 +20,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip

--- a/publish-helper.gradle
+++ b/publish-helper.gradle
@@ -1,33 +1,16 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-task sourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-    from sourceSets.main.allSource
-}
-
-javadoc.failOnError = false
-task javadocJar(type: Jar) {
-    archiveClassifier.set('javadoc')
-    from javadoc
-}
-
-artifacts {
-    archives sourcesJar
-    archives javadocJar
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    withJavadocJar()
+    withSourcesJar()
 }
 
 publishing {
     publications {
-        main(MavenPublication) {
-            artifactId = project.name
+        it.create("main", MavenPublication) {MavenPublication publication ->
             from(components["java"])
-            artifact sourcesJar {
-                classifier "sources"
-            }
-            artifact javadocJar {
-                classifier "javadoc"
-            }
             pom {
                 name = 'macOS keychain helper library'
                 description = 'A helper library to work with the macOS keychain.'


### PR DESCRIPTION
## Description

Against my initial thoughts the nexus plugin won't publish all subprojects automatically. It will register itself into all projects but the main design was that one calls the publish from the commandline. Here we enter a quirk of gradle.

When call a task like `publish` on the commandline gradle will execute all tasks in all subproject matching the name. When one uses `:publish` than it means only in the root project etc.

Since we still use nebular release and don't call the publish task from jenkins we need to wire these dependencies explicitly.

I also found a cleaner way to setup the source and doc jars.

## Changes

* ![FIX] sonar publish of subprojects

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"



