### PR TITLE
Fix issues with non-existing keychain files

### DIFF
--- a/src/main/groovy/com/wooga/security/command/FindPassword.groovy
+++ b/src/main/groovy/com/wooga/security/command/FindPassword.groovy
@@ -41,7 +41,10 @@ trait FindPassword<T extends SecurityCommand> extends MultiKeychainCommand<T> {
         if (printPasswordOnly) {
             arguments << "-w"
         }
-        arguments.addAll(getMultiKeychainsArgument())
+        if(!keychains.empty) {
+            SecurityCommand.validateKeychainsProperty(keychains)
+            arguments.addAll(getMultiKeychainsArgument())
+        }
         arguments
     }
 }

--- a/src/main/groovy/com/wooga/security/command/MultiKeychainCommand.groovy
+++ b/src/main/groovy/com/wooga/security/command/MultiKeychainCommand.groovy
@@ -39,7 +39,6 @@ trait MultiKeychainCommand<T extends SecurityCommand> {
     List<String> getMultiKeychainsArgument() {
         def arguments = []
         if (!keychains.empty) {
-            SecurityCommand.validateKeychainsProperty(keychains)
             arguments.addAll(keychains.collect({ it.path }))
         }
         arguments

--- a/src/main/groovy/com/wooga/security/command/SecurityCommand.groovy
+++ b/src/main/groovy/com/wooga/security/command/SecurityCommand.groovy
@@ -113,7 +113,7 @@ abstract class SecurityCommand<T> {
         validateFileProperty(keychain, "keychain")
     }
 
-    static void validateKeychainsProperty(List<File> keychains) {
+    static void validateKeychainsProperty(Collection<? extends File> keychains) {
         keychains.each {
             validateKeychainProperty(it)
         }

--- a/src/test/groovy/com/wooga/security/SecurityHelper.groovy
+++ b/src/test/groovy/com/wooga/security/SecurityHelper.groovy
@@ -216,6 +216,7 @@ class SecurityHelper {
         def tempOutputDir = File.createTempDir()
         def p12 = new File(tempOutputDir, "cert.p12")
         def args = ['openssl', 'pkcs12',
+                    '-legacy', //apple doesn't support openssl3 format
                     '-export',
                     '-in', cert.path,
                     '-inkey', key.path,

--- a/src/test/groovy/com/wooga/security/SecurityHelper.groovy
+++ b/src/test/groovy/com/wooga/security/SecurityHelper.groovy
@@ -210,13 +210,23 @@ class SecurityHelper {
         createTestCertificatePkcs12(options, key, cert, password)
     }
 
+    static String[] readOpensslVersion() {
+        def p = ['openssl', 'version'].execute()
+        if(p.waitFor() == 0) {
+            def output = p.inputStream.withCloseable {it.readLines().join("\n") }
+            return output.split(" ")[0..1]
+        }
+        return ["", ""]
+    }
+
     static File createTestCertificatePkcs12(Map options = [:], File key, File cert, String password) {
+        def opensslVersion = readOpensslVersion()
         Map defaultOptions = [privateKeyName: "Test Certificate"]
         options = defaultOptions << options
         def tempOutputDir = File.createTempDir()
         def p12 = new File(tempOutputDir, "cert.p12")
         def args = ['openssl', 'pkcs12',
-                    '-legacy', //apple doesn't support openssl3 format
+                     //apple doesn't support openssl3 format
                     '-export',
                     '-in', cert.path,
                     '-inkey', key.path,
@@ -224,6 +234,9 @@ class SecurityHelper {
                     '-name', options['privateKeyName'],
                     '-passout', "pass:${password}"
         ]
+        if(opensslVersion[1].startsWith("3") && opensslVersion[0].toLowerCase() == "openssl") {
+            args.add('-legacy')
+        }
         if (args.execute().waitFor() == 0) {
             return p12
         }

--- a/src/test/groovy/com/wooga/security/command/ListKeychainsSpec.groovy
+++ b/src/test/groovy/com/wooga/security/command/ListKeychainsSpec.groovy
@@ -33,28 +33,6 @@ class ListKeychainsSpec extends SecurityCommandSpec<ListKeychains> {
         !result.empty
     }
 
-    @Unroll("fails with #expectedExeption when #reason")
-    def "fails with exception when property is invalid"() {
-        given: "invalid keychain"
-        command.setProperty(property, value)
-        command.setKeychainSearchList()
-
-        when:
-        command.execute()
-
-        then:
-        def e = thrown(expectedExeption)
-        e.message.matches(messagePattern)
-
-        where:
-        property    | value                    | expectedExeption               | message
-        "keychains" | [new File("/some/file")] | IllegalArgumentException.class | "does not exist"
-        "keychains" | [File.createTempDir()]   | IllegalArgumentException.class | "is not a file"
-
-        reason = "provided ${property} ${message}"
-        messagePattern = /provided keychain.*${message}/
-    }
-
     @Unroll("property #property sets commandline flag #commandlineFlag")
     def "property sets commandline"() {
         given: "set property"


### PR DESCRIPTION
## Description
Fix current errors when dealing with keychains without corresponding files, by not listing those files as valid keychains. Those empty keychains are still written back into the OS by the application. 

To do so, we have to loose restrictions around the `ListKeychains` command, allowing to set (`-s`) non-existing keychains and avoiding throwing an untreated exception for what is a non-fatal error.

## Changes
* ![FIX] `IllegalArgumentException` on keychain write when there is a keychain with no corresponding file present.


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"



